### PR TITLE
make partner_short_name an optional parameter

### DIFF
--- a/radius_proxy/src/config_parser.c
+++ b/radius_proxy/src/config_parser.c
@@ -33,7 +33,7 @@ static struct config_opt opts[] = {
     sizeof(conf_opts.partner_short_name),
     conf_opts.partner_short_name,
     "(Optional) The short name of the partner. Used for logging",
-    NULL},
+    ""},
     {"req_listen_ip",
      CONFIG_FIELD_IPV4,
      sizeof(conf_opts.req_listen_ip),


### PR DESCRIPTION
Summary:
Make the `partner_short_name` optional (default value is "").

*Why is this reasonable?*
When configured on AP, radius_proxy should not send partner name (logs are not sent to WWW).
When running as SaaS, logs should contain partner name.

Differential Revision: D15469408

